### PR TITLE
Adding Tuesdays, ensuring weekends, and Committee should probably approve stuff at some point

### DIFF
--- a/icds-constitution.tex
+++ b/icds-constitution.tex
@@ -124,6 +124,7 @@ References to relevant sections of the Imperial College Union Constitution, Bye-
     \item A meeting must be called by the President upon the request of any three members of the Committee.
     \item The President or their delegated authority shall chair meetings of the Committee.
     \item At least five College days' written notice of planned meetings of the Committee shall be provided by the Secretary to members of the Committee.
+    \item Since time immemorial planned meetings of the Committee have occurred on a Tuesday. This should continue whenever possible, and reasons for deviation noted in the minutes for that meeting.
     \item Unplanned meetings may be held with shorter notice if there is a good reason to do so.
     \item \policyBye{B11} Quorum of the Committee shall be 50\%+1 of the officers of the Committee.
     \item Any Member of the Society may observe Committee meetings as a Guest of the Committee.
@@ -131,7 +132,8 @@ References to relevant sections of the Imperial College Union Constitution, Bye-
     \item A person who is not a Member of the Society may be invited by the Committee to attend a Committee meeting as a Guest of the Committee.
     \item Guests of the Committee must ask permission from the Chair of the meeting to speak (ordinarily the President).
     \item The Secretary or their delegated authority shall circulate agenda for meetings of the Committee no less than one College day in advance of the meeting.
-    \item The Secretary must circulate to the Committee a draft of the meeting's minutes within three college days of the meeting.
+    \item The first agendum of any Committee meeting must be to approve the minutes of any prior meetings as a true and accurate record of the meeting to which they refer, and to note any corrections as upheld by vote if necessary, provided at least five College days has passed since the said minutes' circulation to the Committee. 
+    \item The Secretary must circulate to the Committee a draft of the meeting's minutes within four college days of the meeting.
     \item A member may submit to the Secretary a request to view the draft non-reserved minutes. The Secretary must provide to such a member the draft minutes as soon as possible, so long as:
         \begin{enumerate}
             \item Three College days have passed since the circulation of the draft minutes to the Committee and guests,


### PR DESCRIPTION
Quoting my comment from Pete's pull request:

"I'll merge these for now, but I still think line 134 should be 5 College days to guarantee a weekend.

**An alternative could be to add a point after line 125 saying that planned meetings of the Committee should happen on a Tuesday, and then make it four College days.**

**Also probably worth adding in that the first agendum of a Committee meeting should be to approve any minutes of previous meetings provided five days have passed since their circulation.**

I'll put together a new pull request now."
